### PR TITLE
Add LabelController API to fetch the existing Label

### DIFF
--- a/src/main/java/com/github/regyl/gfi/controller/LabelController.java
+++ b/src/main/java/com/github/regyl/gfi/controller/LabelController.java
@@ -1,0 +1,34 @@
+package com.github.regyl.yagfi.controller;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/labels")
+public class LabelController {
+
+    @GetMapping
+    public ResponseEntity<List<String>> getSupportedLabels() throws IOException {
+        var resource = new ClassPathResource("data/labels.txt");
+
+        List<String> lines = Files.readAllLines(
+                resource.getFile().toPath(),
+                StandardCharsets.UTF_8
+        );
+
+        List<String> labels = lines.stream()
+                .map(String::trim)
+                .filter(line -> !line.isBlank() && !line.startsWith("#"))
+                .toList();
+
+        return ResponseEntity.ok(labels);
+    }
+}


### PR DESCRIPTION
This PR implements **GET /api/labels** – a simple REST endpoint that returns the full list of currently supported labels loaded from `src/main/resources/data/labels.txt`.

**Endpoint details**
- **Method & Path**: `GET /api/labels`
- **Response**: JSON array of strings, e.g.:
  ```json
  [
    "good first issue",
    "good-first-issue",
    "help wanted",
    "beginner-friendly",
    "status: ideal-for-contribution",
    ...
  ]