### PR TITLE
Add kind/quick-win label to supported labels

### DIFF
--- a/src/main/resources/data/labels.txt
+++ b/src/main/resources/data/labels.txt
@@ -51,3 +51,4 @@ up-for-grabs
 help wanted
 help-wanted
 Help Wanted
+kind/quick-win


### PR DESCRIPTION
## Description
This PR adds the `kind/quick-win` label to the list of supported good-first-issue labels.

## Changes
- Added `kind/quick-win` to `src/main/resources/data/labels.txt`

## Reference
- Label is used in [kestra-io/kestra#14341](https://github.com/kestra-io/kestra/issues/14341)
- As suggested in the [CONTRIBUTING.md guide](https://github.com/Regyl/yagfi-back/blob/master/docs/CONTRIBUTING.md#suggest-labels)

Fixes #9