### PR TITLE
Add integration tests for DataRepository#findAllIssues

### DIFF
--- a/src/test/java/com/github/regyl/gfi/repository/DataRepositoryTest.java
+++ b/src/test/java/com/github/regyl/gfi/repository/DataRepositoryTest.java
@@ -1,15 +1,9 @@
 package com.github.regyl.gfi.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Collection;
-import java.util.List;
-
 import com.github.regyl.gfi.annotation.DefaultIntegrationTest;
 import com.github.regyl.gfi.controller.dto.request.issue.DataRequestDto;
 import com.github.regyl.gfi.controller.dto.response.issue.IssueResponseDto;
 import com.github.regyl.gfi.repository.DataRepository;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultIntegrationTest
 @SpringBootTest


### PR DESCRIPTION
This PR adds integration tests for the `findAllIssues` method in `DataRepository`.

## Changes
- Added `FindAllIssues` nested test class with multiple test cases
- `testReturnsIssuesWithNoFilters` - Tests basic issue retrieval
- `testEmptyWhenNoData` - Tests empty result handling
- Added helper methods `insertRepositoryWithDetails` and `insertIssue` for test data setup

## Testing
- Tests follow the existing pattern in `DataRepositoryTest`
- Uses Testcontainers with PostgreSQL for integration testing

Fixes #79
