### PR TITLE
Make issue language ordering deterministic

### DIFF
--- a/src/main/resources/mapper/DataRepository.xml
+++ b/src/main/resources/mapper/DataRepository.xml
@@ -86,7 +86,7 @@
     FROM gfi.issue_v issue
     WHERE issue.language IS NOT NULL
     GROUP BY issue.language
-    ORDER BY COUNT(1) DESC
+    ORDER BY COUNT(1) DESC, issue.language ASC
   </select>
 
 


### PR DESCRIPTION
Add secondary ordering by language to ensure stable
results when multiple languages have the same frequency.