### PR TITLE
test: add arch test to restrict repository dependencies in controllers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <!--tests-->
         <assertj.version>3.27.7</assertj.version>
         <testcontainers.version>2.0.3</testcontainers.version>
+        <archunit.version>1.4.1</archunit.version>
 
         <!--plugins-->
         <jib.version>3.5.1</jib.version>
@@ -195,6 +196,18 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5-api</artifactId>
+            <version>${archunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5-engine</artifactId>
+            <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/github/regyl/gfi/controller/ControllerArchTest.java
+++ b/src/test/java/com/github/regyl/gfi/controller/ControllerArchTest.java
@@ -1,0 +1,18 @@
+package com.github.regyl.gfi.controller;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@AnalyzeClasses(packages = "com.github.regyl.gfi")
+class ControllerArchTest {
+
+    @ArchTest
+    static final ArchRule controllersShouldNotDependOnRepositories =
+            noClasses()
+                    .that().resideInAPackage("..controller..")
+                    .should().dependOnClassesThat()
+                    .resideInAPackage("..repository..");
+}


### PR DESCRIPTION
Sample failing test if a repository dependency is found in controller classes

`[ERROR]   ControllerArchTest.controllersShouldNotDependOnRepositories Architecture Violation [Priority: MEDIUM] - Rule 'no classes that reside in a package '..controller..' should depend on classes that reside in a package '..repository..'' was violated (2 times):
Constructor <com.github.regyl.gfi.controller.DataController.<init>(com.github.regyl.gfi.service.other.DataService, com.github.regyl.gfi.repository.DataRepository)> has parameter of type <com.github.regyl.gfi.repository.DataRepository> in (DataController.java:0)
Field <com.github.regyl.gfi.controller.DataController.dataRepository> has type <com.github.regyl.gfi.repository.DataRepository> in (DataController.java:0)`

Fixes: #96 