### PR TITLE
IssueLoader wait for Githubmetadata & mock tests

### DIFF
--- a/src/main/java/com/github/regyl/gfi/configuration/lock/LockConfig.java
+++ b/src/main/java/com/github/regyl/gfi/configuration/lock/LockConfig.java
@@ -1,0 +1,14 @@
+package com.github.regyl.gfi.configuration.lock;
+
+import java.util.concurrent.CountDownLatch;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LockConfig {
+
+    @Bean
+    public CountDownLatch metadataLatch() {
+        return new CountDownLatch(1);
+    }
+}

--- a/src/main/java/com/github/regyl/gfi/configuration/lock/LockConfig.java
+++ b/src/main/java/com/github/regyl/gfi/configuration/lock/LockConfig.java
@@ -1,8 +1,9 @@
 package com.github.regyl.gfi.configuration.lock;
 
-import java.util.concurrent.CountDownLatch;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.CountDownLatch;
 
 @Configuration
 public class LockConfig {

--- a/src/main/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImpl.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImpl.java
@@ -1,11 +1,5 @@
 package com.github.regyl.gfi.service.impl;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Supplier;
-
 import com.github.regyl.gfi.entity.GitHubMetadataEntity;
 import com.github.regyl.gfi.model.LabelModel;
 import com.github.regyl.gfi.model.MetadataRequestModel;
@@ -20,6 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+
 
 @Slf4j
 @Component

--- a/src/main/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImpl.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImpl.java
@@ -1,5 +1,11 @@
 package com.github.regyl.gfi.service.impl;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+
 import com.github.regyl.gfi.entity.GitHubMetadataEntity;
 import com.github.regyl.gfi.model.LabelModel;
 import com.github.regyl.gfi.model.MetadataRequestModel;
@@ -15,11 +21,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.function.Supplier;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -31,25 +32,29 @@ public class GithubMetadataLoaderServiceImpl implements ScheduledService {
     @Qualifier("scrappingStartDate")
     private final Supplier<LocalDate> scrappingStartDate;
     private final GitHubMetadataRepository metadataRepository;
+    private final CountDownLatch metadataLatch;
 
     @Async
-    @Override
-    @Scheduled(fixedRate = 604_800_000, initialDelay = 1_000) //1 week
+    @Scheduled(fixedRate = 604_800_000, initialDelay = 1_000)
     public void schedule() {
-        String dateFilter = scrappingStartDate.get().toString();
-        log.info("Start collecting GitHub metadata for labels from {}", dateFilter);
-        Collection<LabelModel> labels = labelService.findAll();
+        try {
+            String dateFilter = scrappingStartDate.get().toString();
+            log.info("Start collecting GitHub metadata for labels from {}", dateFilter);
+            Collection<LabelModel> labels = labelService.findAll();
 
-        Collection<GitHubMetadataEntity> entities = new ArrayList<>();
-        for (LabelModel labelModel : labels) {
-            String label = labelModel.getTitle();
-            MetadataRequestModel model = new MetadataRequestModel(label, dateFilter);
-            int totalCount = githubClient.execute(model);
-            log.info("Found {} GitHub issues for label {}", totalCount, label);
-            entities.add(new GitHubMetadataEntity(label, totalCount));
+            Collection<GitHubMetadataEntity> entities = new ArrayList<>();
+            for (LabelModel labelModel : labels) {
+                String label = labelModel.getTitle();
+                MetadataRequestModel model = new MetadataRequestModel(label, dateFilter);
+                int totalCount = githubClient.execute(model);
+                log.info("Found {} GitHub issues for label {}", totalCount, label);
+                entities.add(new GitHubMetadataEntity(label, totalCount));
+            }
+
+            metadataRepository.saveAll(entities);
+            log.info("Finished collecting GitHub metadata for labels");
+        } finally {
+            metadataLatch.countDown();
         }
-
-        metadataRepository.saveAll(entities);
-        log.info("Finished collecting GitHub metadata for labels");
     }
 }

--- a/src/test/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImplTest.java
@@ -1,12 +1,5 @@
 package com.github.regyl.gfi.service.impl;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Supplier;
-
-import static org.mockito.Mockito.when;
-
 import com.github.regyl.gfi.annotation.DefaultUnitTest;
 import com.github.regyl.gfi.model.MetadataRequestModel;
 import com.github.regyl.gfi.repository.GitHubMetadataRepository;
@@ -16,6 +9,13 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.when;
 
 @DefaultUnitTest
 class GithubMetadataLoaderServiceImplTest {

--- a/src/test/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImplTest.java
@@ -1,0 +1,62 @@
+package com.github.regyl.gfi.service.impl;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.when;
+
+import com.github.regyl.gfi.annotation.DefaultUnitTest;
+import com.github.regyl.gfi.model.MetadataRequestModel;
+import com.github.regyl.gfi.repository.GitHubMetadataRepository;
+import com.github.regyl.gfi.service.github.GithubClientService;
+import com.github.regyl.gfi.service.other.LabelService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@DefaultUnitTest
+class GithubMetadataLoaderServiceImplTest {
+
+    private GithubMetadataLoaderServiceImpl target;
+
+    @Mock
+    private GithubClientService<MetadataRequestModel, Integer> githubClient;
+    @Mock
+    private LabelService labelService;
+    @Mock
+    private GitHubMetadataRepository metadataRepository;
+
+    private CountDownLatch metadataLatch;
+
+    private final Supplier<LocalDate> scrappingStartDate = () -> LocalDate.of(2024, 1, 1);
+
+    @BeforeEach
+    void setUp() {
+        metadataLatch = new CountDownLatch(1);
+        target = new GithubMetadataLoaderServiceImpl(
+                githubClient, labelService, scrappingStartDate, metadataRepository, metadataLatch
+        );
+    }
+
+    @Test
+    void testSchedule_latchReleasedAfterExecution() {
+        when(labelService.findAll()).thenReturn(List.of());
+
+        target.schedule();
+
+        Assertions.assertThat(metadataLatch.getCount()).isZero();
+    }
+
+    @Test
+    void testSchedule_latchReleasedEvenOnError() {
+        when(labelService.findAll()).thenThrow(new RuntimeException("error"));
+
+        Assertions.assertThatThrownBy(() -> target.schedule())
+                .isInstanceOf(RuntimeException.class);
+
+        Assertions.assertThat(metadataLatch.getCount()).isZero();
+    }
+}

--- a/src/test/java/com/github/regyl/gfi/service/impl/IssueLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/IssueLoaderServiceImplTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/github/regyl/gfi/service/impl/IssueLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/IssueLoaderServiceImplTest.java
@@ -1,0 +1,54 @@
+package com.github.regyl.gfi.service.impl;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.regyl.gfi.annotation.DefaultUnitTest;
+import com.github.regyl.gfi.model.IssueTables;
+import com.github.regyl.gfi.service.impl.issueload.IssueLoaderServiceImpl;
+import com.github.regyl.gfi.service.issueload.IssueSourceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.cache.CacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@DefaultUnitTest
+class IssueLoaderServiceImplTest {
+
+    private IssueLoaderServiceImpl target;
+
+    @Mock
+    private IssueSourceService sourceService;
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        target = new IssueLoaderServiceImpl(
+                List.of(sourceService), jdbcTemplate, cacheManager, new CountDownLatch(0)
+        );
+    }
+
+    @Test
+    void testSchedule_uploadsAndRaisesEvent() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class))).thenReturn(0L);
+        when(sourceService.upload(any(IssueTables.class)))
+                .thenReturn(List.of(CompletableFuture.completedFuture(null)));
+        when(cacheManager.getCacheNames()).thenReturn(List.of());
+
+        target.schedule();
+
+        verify(sourceService).upload(any(IssueTables.class));
+        verify(sourceService).raiseUploadEvent();
+    }
+}

--- a/src/test/java/com/github/regyl/gfi/service/impl/IssueLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/IssueLoaderServiceImplTest.java
@@ -1,15 +1,5 @@
 package com.github.regyl.gfi.service.impl;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.github.regyl.gfi.annotation.DefaultUnitTest;
 import com.github.regyl.gfi.model.IssueTables;
 import com.github.regyl.gfi.service.impl.issueload.IssueLoaderServiceImpl;
@@ -19,6 +9,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.cache.CacheManager;
 import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 
 @DefaultUnitTest
 class IssueLoaderServiceImplTest {
@@ -41,7 +41,6 @@ class IssueLoaderServiceImplTest {
 
     @Test
     void testSchedule_uploadsAndRaisesEvent() {
-        when(jdbcTemplate.queryForObject(anyString(), eq(Long.class))).thenReturn(0L);
         when(sourceService.upload(any(IssueTables.class)))
                 .thenReturn(List.of(CompletableFuture.completedFuture(null)));
         when(cacheManager.getCacheNames()).thenReturn(List.of());


### PR DESCRIPTION
## What this PR does
- Adds a CountDownLatch bean in LockConfig to synchronize the two scheduled services
- GithubMetadataLoaderServiceImpl now calls countDown() after finishing metadata collection
- IssueLoaderServiceImpl now calls await() before starting to ensure metadata is ready

## Why
IssueLoaderServiceImpl was starting before GithubMetadataLoaderServiceImpl finished,
causing issues with missing metadata.

## Testing
- Added unit tests for GithubMetadataLoaderServiceImpl
- Added unit tests for IssueLoaderServiceImpl