### PR TITLE
Add unit test for UserFeedRequestDtoToEntityMapperImpl

### DIFF
--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -1,7 +1,4 @@
 package com.github.regyl.gfi.mapper;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.OffsetDateTime;
 import java.util.function.Supplier;
@@ -10,34 +7,36 @@ import org.junit.jupiter.api.Test;
 
 import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 class UserFeedRequestDtoToEntityMapperImplTest {
 
-    @Test
-    void shouldThrowExceptionWhenInputIsNull() {
-        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
-        UserFeedRequestDtoToEntityMapperImpl mapper =
-                new UserFeedRequestDtoToEntityMapperImpl(supplier);
+	@Test
+	void shouldThrowExceptionWhenInputIsNull() {
+		Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+		UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
 
-        assertThrows(NullPointerException.class, () -> mapper.apply(null));
-    }
+		assertThrows(NullPointerException.class, () -> mapper.apply(null));
+	}
 
-    @Test
-    void shouldMapAllFieldsCorrectly() {
-        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+	@Test
+	void shouldMapAllFieldsCorrectly() {
+		Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
 
-        UserFeedRequestDtoToEntityMapperImpl mapper =
-                new UserFeedRequestDtoToEntityMapperImpl(supplier);
+		UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
 
-        UserFeedRequestDto dto = new UserFeedRequestDto();
-        dto.setNickname("TestUser");
-        dto.setEmail("user@test.com");
+		UserFeedRequestDto dto = new UserFeedRequestDto();
+		dto.setNickname("TestUser");
+		dto.setEmail("user@test.com");
 
-        var entity = mapper.apply(dto);
+		var entity = mapper.apply(dto);
 
-        assertNotNull(entity);
-        assertEquals("TestUser", entity.getNickname());
-        assertEquals("user@test.com", entity.getEmail());
-        assertNotNull(entity.getCreated());
-        assertNotNull(entity.getStatus());
-    }
+		assertNotNull(entity);
+		assertEquals("TestUser", entity.getNickname());
+		assertEquals("user@test.com", entity.getEmail());
+		assertNotNull(entity.getCreated());
+		assertNotNull(entity.getStatus());
+	}
 }

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -3,14 +3,32 @@ package com.github.regyl.gfi.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.time.OffsetDateTime;
 import java.util.function.Supplier;
-
 import org.junit.jupiter.api.Test;
-
 import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
 
 class UserFeedRequestDtoToEntityMapperImplTest {
-    // ...
+
+    @Test
+    void shouldThrowExceptionWhenInputIsNull() {
+        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+        UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
+        assertThrows(NullPointerException.class, () -> mapper.apply(null));
+    }
+
+    @Test
+    void shouldMapAllFieldsCorrectly() {
+        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+        UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
+        UserFeedRequestDto dto = new UserFeedRequestDto();
+        dto.setNickname("testUser");
+        dto.setEmail("user@test.com");
+        var entity = mapper.apply(dto);
+        assertNotNull(entity);
+        assertEquals("testUser", entity.getNickname());
+        assertEquals("user@test.com", entity.getEmail());
+        assertNotNull(entity.getCreated());
+        assertNotNull(entity.getStatus());
+    }
 }

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -1,5 +1,9 @@
 package com.github.regyl.gfi.mapper;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.time.OffsetDateTime;
 import java.util.function.Supplier;
 
@@ -7,31 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 class UserFeedRequestDtoToEntityMapperImplTest {
-
-    @Test
-    void shouldThrowExceptionWhenInputIsNull() {
-        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
-        UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
-        assertThrows(NullPointerException.class, () -> mapper.apply(null));
-    }
-
-    @Test
-    void shouldMapAllFieldsCorrectly() {
-        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
-        UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
-        UserFeedRequestDto dto = new UserFeedRequestDto();
-        dto.setNickname("testUser");
-        dto.setEmail("user@test.com");
-        var entity = mapper.apply(dto);
-        assertNotNull(entity);
-        assertEquals("testUser", entity.getNickname());
-        assertEquals("user@test.com", entity.getEmail());
-        assertNotNull(entity.getCreated());
-        assertNotNull(entity.getStatus());
-    }
+    // ...
 }

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -1,15 +1,15 @@
 package com.github.regyl.gfi.mapper;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.time.OffsetDateTime;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
 import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserFeedRequestDtoToEntityMapperImplTest {
 

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -1,0 +1,43 @@
+package com.github.regyl.gfi.mapper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.OffsetDateTime;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
+
+class UserFeedRequestDtoToEntityMapperImplTest {
+
+    @Test
+    void shouldThrowExceptionWhenInputIsNull() {
+        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+        UserFeedRequestDtoToEntityMapperImpl mapper =
+                new UserFeedRequestDtoToEntityMapperImpl(supplier);
+
+        assertThrows(NullPointerException.class, () -> mapper.apply(null));
+    }
+
+    @Test
+    void shouldMapAllFieldsCorrectly() {
+        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+
+        UserFeedRequestDtoToEntityMapperImpl mapper =
+                new UserFeedRequestDtoToEntityMapperImpl(supplier);
+
+        UserFeedRequestDto dto = new UserFeedRequestDto();
+        dto.setNickname("TestUser");
+        dto.setEmail("user@test.com");
+
+        var entity = mapper.apply(dto);
+
+        assertNotNull(entity);
+        assertEquals("TestUser", entity.getNickname());
+        assertEquals("user@test.com", entity.getEmail());
+        assertNotNull(entity.getCreated());
+        assertNotNull(entity.getStatus());
+    }
+}

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -13,30 +13,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserFeedRequestDtoToEntityMapperImplTest {
 
-	@Test
-	void shouldThrowExceptionWhenInputIsNull() {
-		Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
-		UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
+    @Test
+    void shouldThrowExceptionWhenInputIsNull() {
+        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+        UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
+        assertThrows(NullPointerException.class, () -> mapper.apply(null));
+    }
 
-		assertThrows(NullPointerException.class, () -> mapper.apply(null));
-	}
-
-	@Test
-	void shouldMapAllFieldsCorrectly() {
-		Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
-
-		UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
-
-		UserFeedRequestDto dto = new UserFeedRequestDto();
-		dto.setNickname("testUser");
-		dto.setEmail("user@test.com");
-
-		var entity = mapper.apply(dto);
-
-		assertNotNull(entity);
-		assertEquals("testUser", entity.getNickname());
-		assertEquals("user@test.com", entity.getEmail());
-		assertNotNull(entity.getCreated());
-		assertNotNull(entity.getStatus());
-	}
+    @Test
+    void shouldMapAllFieldsCorrectly() {
+        Supplier<OffsetDateTime> supplier = OffsetDateTime::now;
+        UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
+        UserFeedRequestDto dto = new UserFeedRequestDto();
+        dto.setNickname("testUser");
+        dto.setEmail("user@test.com");
+        var entity = mapper.apply(dto);
+        assertNotNull(entity);
+        assertEquals("testUser", entity.getNickname());
+        assertEquals("user@test.com", entity.getEmail());
+        assertNotNull(entity.getCreated());
+        assertNotNull(entity.getStatus());
+    }
 }

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -1,12 +1,15 @@
 package com.github.regyl.gfi.mapper;
 
+import java.time.OffsetDateTime;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import java.time.OffsetDateTime;
-import java.util.function.Supplier;
-import org.junit.jupiter.api.Test;
-import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
 
 class UserFeedRequestDtoToEntityMapperImplTest {
 

--- a/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/mapper/UserFeedRequestDtoToEntityMapperImplTest.java
@@ -1,15 +1,15 @@
 package com.github.regyl.gfi.mapper;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.time.OffsetDateTime;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
 import com.github.regyl.gfi.dto.request.feed.UserFeedRequestDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserFeedRequestDtoToEntityMapperImplTest {
 
@@ -28,13 +28,13 @@ class UserFeedRequestDtoToEntityMapperImplTest {
 		UserFeedRequestDtoToEntityMapperImpl mapper = new UserFeedRequestDtoToEntityMapperImpl(supplier);
 
 		UserFeedRequestDto dto = new UserFeedRequestDto();
-		dto.setNickname("TestUser");
+		dto.setNickname("testUser");
 		dto.setEmail("user@test.com");
 
 		var entity = mapper.apply(dto);
 
 		assertNotNull(entity);
-		assertEquals("TestUser", entity.getNickname());
+		assertEquals("testUser", entity.getNickname());
 		assertEquals("user@test.com", entity.getEmail());
 		assertNotNull(entity.getCreated());
 		assertNotNull(entity.getStatus());


### PR DESCRIPTION
Added unit tests for UserFeedRequestDtoToEntityMapperImpl.

Includes:
- Null input test (throws exception)
- Fully filled DTO mapping test

Followed Given/When/Then approach as mentioned in issue #82.