### PR TITLE
Add retry logic for BadGateway exception (#57)

### DIFF
--- a/src/main/java/com/github/regyl/gfi/service/impl/github/AbstractGraphQlGithubClientService.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/github/AbstractGraphQlGithubClientService.java
@@ -53,7 +53,7 @@ public abstract class AbstractGraphQlGithubClientService<T, S> implements Github
                 }
 
                 try {
-                    Thread.sleep(2000); // wait before retry
+                    Thread.sleep(2000);
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
                 }

--- a/src/main/java/com/github/regyl/gfi/service/impl/github/AbstractGraphQlGithubClientService.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/github/AbstractGraphQlGithubClientService.java
@@ -1,17 +1,20 @@
 package com.github.regyl.gfi.service.impl.github;
 
-import com.github.regyl.gfi.exception.RateLimitExceedException;
-import com.github.regyl.gfi.service.github.GithubClientService;
-import com.google.common.util.concurrent.RateLimiter;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.graphql.client.ClientGraphQlResponse;
 import org.springframework.graphql.client.GraphQlClient;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 
-import java.util.Map;
+import com.github.regyl.gfi.exception.RateLimitExceedException;
+import com.github.regyl.gfi.service.github.GithubClientService;
+import com.google.common.util.concurrent.RateLimiter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -20,23 +23,48 @@ public abstract class AbstractGraphQlGithubClientService<T, S> implements Github
     @Autowired
     @Qualifier("githubRateLimiter")
     private RateLimiter rateLimiter;
+
     @Autowired
     private GraphQlClient githubClient;
 
     @Override
     public S execute(T rq) {
         Map<String, Object> variables = toVariables(rq);
-        try {
-            rateLimiter.acquire();
-            return run0(variables);
-        } catch (HttpClientErrorException.Forbidden e) {
-            //https://docs.github.com/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#secondary-rate-limits
-            log.error("Exceeded a secondary rate limit: {}", e.getMessage());
-            throw new RateLimitExceedException();
-        } catch (Exception e) {
-            log.error("Error fetching github GraphQL response for params: {}", variables, e);
-            return null;
+
+        int maxRetries = 3;
+        int attempt = 0;
+
+        while (attempt < maxRetries) {
+            try {
+                rateLimiter.acquire();
+                return run0(variables);
+
+            } catch (HttpClientErrorException.Forbidden e) {
+                log.error("Exceeded a secondary rate limit: {}", e.getMessage());
+                throw new RateLimitExceedException();
+
+            } catch (HttpServerErrorException.BadGateway e) {
+                attempt++;
+                log.warn("Bad Gateway error, retrying... attempt {}/{}", attempt, maxRetries);
+
+                if (attempt >= maxRetries) {
+                    log.error("Max retries reached. Failing request.");
+                    return null;
+                }
+
+                try {
+                    Thread.sleep(2000); // wait before retry
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+
+            } catch (Exception e) {
+                log.error("Error fetching github GraphQL response for params: {}", variables, e);
+                return null;
+            }
         }
+
+        return null;
     }
 
     protected abstract Map<String, Object> toVariables(T rq);
@@ -47,9 +75,11 @@ public abstract class AbstractGraphQlGithubClientService<T, S> implements Github
 
     private S run0(Map<String, Object> variables) {
         String query = getQuery();
+
         ClientGraphQlResponse clientGraphQlResponse = githubClient.document(query)
                 .variables(variables)
                 .executeSync();
+
         if (!clientGraphQlResponse.isValid()) {
             log.error("graph ql response is invalid");
         }


### PR DESCRIPTION
This PR adds retry logic for handling HttpServerErrorException.BadGateway (502) errors.

- Implemented retry mechanism with a maximum of 3 attempts
- Added delay between retries to handle temporary failures
- Prevents immediate failure on transient GitHub API errors

Fixes #57