### PR TITLE
fix: prevent metadata updates during issue loading

### DIFF
--- a/src/main/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImpl.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImpl.java
@@ -6,6 +6,7 @@ import com.github.regyl.gfi.model.MetadataRequestModel;
 import com.github.regyl.gfi.repository.GitHubMetadataRepository;
 import com.github.regyl.gfi.service.ScheduledService;
 import com.github.regyl.gfi.service.github.GithubClientService;
+import com.github.regyl.gfi.service.impl.issueload.IssueLoadingLockService;
 import com.github.regyl.gfi.service.other.LabelService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,11 +32,17 @@ public class GithubMetadataLoaderServiceImpl implements ScheduledService {
     @Qualifier("scrappingStartDate")
     private final Supplier<LocalDate> scrappingStartDate;
     private final GitHubMetadataRepository metadataRepository;
+    private final IssueLoadingLockService issueLoadingLockService;
 
     @Async
     @Override
     @Scheduled(fixedRate = 604_800_000, initialDelay = 1_000) //1 week
     public void schedule() {
+        if (issueLoadingLockService.isIssueLoadInProgress()) {
+            log.info("Skip metadata load because issue loading is in progress");
+            return;
+        }
+
         String dateFilter = scrappingStartDate.get().toString();
         log.info("Start collecting GitHub metadata for labels from {}", dateFilter);
         Collection<LabelModel> labels = labelService.findAll();

--- a/src/main/java/com/github/regyl/gfi/service/impl/issueload/IssueLoaderServiceImpl.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/issueload/IssueLoaderServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 public class IssueLoaderServiceImpl implements ScheduledService {
 
     private final Collection<IssueSourceService> sourceServices;
+    private final IssueLoadingLockService issueLoadingLockService;
 
     private final JdbcTemplate jdbcTemplate;
     private final CacheManager cacheManager;
@@ -29,19 +30,28 @@ public class IssueLoaderServiceImpl implements ScheduledService {
     @Override
     @Scheduled(fixedRateString = "${spring.properties.auto-upload.period-mills}", initialDelay = 1000)
     public void schedule() {
+        if (!issueLoadingLockService.tryAcquireIssueLoadLock()) {
+            log.info("Issue load task is already running, skip this execution");
+            return;
+        }
+
         log.info("Start issue load task");
-        IssueTables table = determineTable();
-        Collection<CompletableFuture<Void>> futures = sourceServices.stream()
-                .flatMap(service -> service.upload(table).stream())
-                .toList();
+        try {
+            IssueTables table = determineTable();
+            Collection<CompletableFuture<Void>> futures = sourceServices.stream()
+                    .flatMap(service -> service.upload(table).stream())
+                    .toList();
 
-        //waiting all issues to be done
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+            //waiting all issues to be done
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
-        sourceServices.forEach(IssueSourceService::raiseUploadEvent);
+            sourceServices.forEach(IssueSourceService::raiseUploadEvent);
 
-        replaceView(table);
-        log.info("Issue load finished");
+            replaceView(table);
+            log.info("Issue load finished");
+        } finally {
+            issueLoadingLockService.releaseIssueLoadLock();
+        }
     }
 
     private IssueTables determineTable() {

--- a/src/main/java/com/github/regyl/gfi/service/impl/issueload/IssueLoadingLockService.java
+++ b/src/main/java/com/github/regyl/gfi/service/impl/issueload/IssueLoadingLockService.java
@@ -1,0 +1,23 @@
+package com.github.regyl.gfi.service.impl.issueload;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+public class IssueLoadingLockService {
+
+    private final AtomicBoolean issueLoadInProgress = new AtomicBoolean(false);
+
+    public boolean tryAcquireIssueLoadLock() {
+        return issueLoadInProgress.compareAndSet(false, true);
+    }
+
+    public void releaseIssueLoadLock() {
+        issueLoadInProgress.set(false);
+    }
+
+    public boolean isIssueLoadInProgress() {
+        return issueLoadInProgress.get();
+    }
+}

--- a/src/test/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/GithubMetadataLoaderServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.github.regyl.gfi.service.impl;
+
+import com.github.regyl.gfi.annotation.DefaultUnitTest;
+import com.github.regyl.gfi.model.MetadataRequestModel;
+import com.github.regyl.gfi.repository.GitHubMetadataRepository;
+import com.github.regyl.gfi.service.github.GithubClientService;
+import com.github.regyl.gfi.service.impl.issueload.IssueLoadingLockService;
+import com.github.regyl.gfi.service.other.LabelService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@DefaultUnitTest
+class GithubMetadataLoaderServiceImplTest {
+
+    @Test
+    void shouldSkipWhenIssueLoadInProgress() {
+        GithubClientService<MetadataRequestModel, Integer> githubClient = Mockito.mock(GithubClientService.class);
+        LabelService labelService = Mockito.mock(LabelService.class);
+        GitHubMetadataRepository metadataRepository = Mockito.mock(GitHubMetadataRepository.class);
+        Supplier<LocalDate> scrappingStartDate = () -> LocalDate.of(2025, 1, 1);
+        IssueLoadingLockService lockService = new IssueLoadingLockService();
+        lockService.tryAcquireIssueLoadLock();
+
+        GithubMetadataLoaderServiceImpl target = new GithubMetadataLoaderServiceImpl(
+                githubClient,
+                labelService,
+                scrappingStartDate,
+                metadataRepository,
+                lockService
+        );
+
+        target.schedule();
+
+        verifyNoInteractions(githubClient, labelService, metadataRepository);
+    }
+}

--- a/src/test/java/com/github/regyl/gfi/service/impl/issueload/IssueLoaderServiceImplTest.java
+++ b/src/test/java/com/github/regyl/gfi/service/impl/issueload/IssueLoaderServiceImplTest.java
@@ -1,0 +1,64 @@
+package com.github.regyl.gfi.service.impl.issueload;
+
+import com.github.regyl.gfi.annotation.DefaultUnitTest;
+import com.github.regyl.gfi.model.IssueTables;
+import com.github.regyl.gfi.service.issueload.IssueSourceService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.cache.CacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DefaultUnitTest
+class IssueLoaderServiceImplTest {
+
+    @Test
+    void shouldSkipWhenIssueLoadAlreadyRunning() {
+        IssueSourceService sourceService = Mockito.mock(IssueSourceService.class);
+        JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+        CacheManager cacheManager = Mockito.mock(CacheManager.class);
+        IssueLoadingLockService lockService = new IssueLoadingLockService();
+        lockService.tryAcquireIssueLoadLock();
+
+        IssueLoaderServiceImpl target = new IssueLoaderServiceImpl(
+                List.of(sourceService),
+                lockService,
+                jdbcTemplate,
+                cacheManager
+        );
+
+        target.schedule();
+
+        verifyNoInteractions(sourceService, jdbcTemplate);
+    }
+
+    @Test
+    void shouldReleaseLockWhenIssueLoadFails() {
+        IssueSourceService sourceService = Mockito.mock(IssueSourceService.class);
+        JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+        CacheManager cacheManager = Mockito.mock(CacheManager.class);
+        IssueLoadingLockService lockService = new IssueLoadingLockService();
+        IssueLoaderServiceImpl target = new IssueLoaderServiceImpl(
+                List.of(sourceService),
+                lockService,
+                jdbcTemplate,
+                cacheManager
+        );
+
+        when(jdbcTemplate.queryForObject(Mockito.anyString(), eq(Long.class))).thenReturn(0L);
+        when(sourceService.upload(eq(IssueTables.FIRST)))
+                .thenReturn(List.of(CompletableFuture.failedFuture(new RuntimeException("boom"))));
+
+        assertThatThrownBy(target::schedule).isInstanceOf(CompletionException.class);
+        assertThat(lockService.isIssueLoadInProgress()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared in-memory lock service to mark issue-load execution windows
- guard IssueLoaderServiceImpl from overlapping runs and release lock in `finally`
- skip GithubMetadataLoaderServiceImpl scheduled metadata refresh while issue loading is in progress
- add focused unit tests for skip behavior and lock release on failure

## Test plan
- [x] IssueLoaderServiceImplTest passes
- [x] GithubMetadataLoaderServiceImplTest passes
- [x] Manual verification: build successful with 3 tests passed on local environment