### PR TITLE
fix: make application entry point public

### DIFF
--- a/src/main/java/com/github/regyl/gfi/YagfiApplication.java
+++ b/src/main/java/com/github/regyl/gfi/YagfiApplication.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 @ConfigurationPropertiesScan(basePackages = "com.github.regyl.gfi.configuration")
 public class YagfiApplication {
 
-    static void main(String[] args) {
+   public static void main(String[] args) {
         SpringApplication.run(YagfiApplication.class, args);
     }
 


### PR DESCRIPTION
## Summary

This PR updates the application entry point to use the standard Java signature.

### Changes
- Changed `static void main(String[] args)` to `public static void main(String[] args)` in `YagfiApplication`.

### Reason
This follows the standard Java application entry point convention.